### PR TITLE
Fixes to build on latest Borealis.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "application/libs/borealis"]
 	path = application/libs/borealis
-	url = https://github.com/WerWolv/borealis
+	url = https://github.com/natinusala/borealis
 [submodule "application/libs/json"]
 	path = application/libs/json
 	url = https://github.com/nlohmann/json

--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -4,7 +4,7 @@
             "name": "DKP Aarch64 Windows",
             "includePath": [
                 "C:/devkitPro/devkitA64/aarch64-none-elf/include/**",
-                "C:/devkitPro/devkitA64/lib/gcc/aarch64-none-elf/9.2.0/include/**",
+                "C:/devkitPro/devkitA64/lib/gcc/aarch64-none-elf/10.1.0/include/**",
                 "C:/devkitPro/libnx/include/**",
                 "C:/devkitPro/portlibs/switch/include/**",
                 "C:/devkitPro/portlibs/switch/include/freetype2/**",
@@ -26,7 +26,7 @@
                 "VERSION_MICRO=0",
                 "SNAPSHOT=0",
                 "VERSION_STRING=\"v0.0.0\"",
-                "BOREALIS_RESOURCES=\"romfs:/borealis/\"",
+                "BOREALIS_RESOURCES",
                 "__SWITCH__",
                 "__aarch64__"
             ],
@@ -39,7 +39,7 @@
             "name": "DKP Aarch64 Linux",
             "includePath": [
                 "/opt/devkitpro/devkitA64/aarch64-none-elf/include/**",
-                "/opt/devkitpro/devkitA64/lib/gcc/aarch64-none-elf/9.2.0/include/**",
+                "/opt/devkitpro/devkitA64/lib/gcc/aarch64-none-elf/10.1.0/include/**",
                 "/opt/devkitpro/libnx/include/**",
                 "/opt/devkitpro/portlibs/switch/include/**",
                 "/opt/devkitpro/portlibs/switch/include/**",
@@ -61,7 +61,7 @@
                 "VERSION_MICRO=0",
                 "SNAPSHOT=0",
                 "VERSION_STRING=\"v0.0.0\"",
-                "BOREALIS_RESOURCES=\"romfs:/borealis/\"",
+                "BOREALIS_RESOURCES",
                 "__SWITCH__",
                 "__aarch64__"
             ],

--- a/application/include/ui/elements/credit_view.hpp
+++ b/application/include/ui/elements/credit_view.hpp
@@ -28,10 +28,7 @@ namespace edz::ui::element {
     public:
         CreditView();
         virtual ~CreditView();
-        View* requestFocus(brls::FocusDirection direction, View *oldFocus, bool fromUp = false) override;
         void draw(NVGcontext* vg, int x, int y, unsigned width, unsigned height, brls::Style* style, brls::FrameContext* ctx) override;
-
-        void drawHighlight(NVGcontext* vg, brls::ThemeValues* theme, float alpha, brls::Style* style, bool background) override;
         
         void layout(NVGcontext* vg, brls::Style *style, brls::FontStash *stash) override;
     };

--- a/application/include/ui/elements/focusable_table.hpp
+++ b/application/include/ui/elements/focusable_table.hpp
@@ -38,9 +38,7 @@ namespace edz::ui::element {
     public:
         FocusableTable();
         virtual ~FocusableTable();
-        View* requestFocus(brls::FocusDirection direction, View *oldFocus, bool fromUp = false) override;
-
-        void drawHighlight(NVGcontext* vg, brls::ThemeValues* theme, float alpha, brls::Style* style, bool background) override;
+        View* getDefaultFocus() override;
     };
 
 }

--- a/application/include/ui/elements/hex_editor.hpp
+++ b/application/include/ui/elements/hex_editor.hpp
@@ -45,8 +45,8 @@ namespace edz::ui::element {
         
         void draw(NVGcontext *vg, int x, int y, unsigned width, unsigned height, brls::Style *style, brls::FrameContext *ctx) override;
         void layout(NVGcontext* vg, brls::Style *style, brls::FontStash *stash) override;
-        brls::View* requestFocus(brls::FocusDirection direction, View *oldFocus, bool fromUp = false) override;
-        void drawHighlight(NVGcontext* vg, brls::ThemeValues* theme, float alpha, brls::Style* style, bool background) override;
+        brls::View* getNextFocus(brls::FocusDirection direction, void* oldFocus) override;
+        brls::View* getDefaultFocus() override;
         bool onClick();
 
         void setBuffer(u8* buffer, size_t size);

--- a/application/include/ui/elements/title_button.hpp
+++ b/application/include/ui/elements/title_button.hpp
@@ -35,7 +35,7 @@ namespace edz::ui::element {
 
         void draw(NVGcontext *vg, int x, int y, unsigned width, unsigned height, brls::Style *style, brls::FrameContext *ctx) override;
         void layout(NVGcontext* vg, brls::Style *style, brls::FontStash *stash) override;
-        brls::View* requestFocus(brls::FocusDirection direction, View *oldFocus, bool fromUp = false) override;
+        brls::View* getDefaultFocus() override;
         bool onClick();
 
         brls::GenericEvent* getClickEvent() {
@@ -62,7 +62,7 @@ namespace edz::ui::element {
             std::vector<brls::BoxLayoutChild*> getChildren();
             void addTitle(std::unique_ptr<save::Title> &title);
             brls::View* defaultFocus(brls::View *oldFocus);
-            brls::View* requestFocus(brls::FocusDirection direction, View *oldFocus, bool fromUp = false) override;
+            brls::View* getNextFocus(brls::FocusDirection direction, void* oldFocus) override;
             
     };
 

--- a/application/include/ui/elements/title_info.hpp
+++ b/application/include/ui/elements/title_info.hpp
@@ -38,9 +38,7 @@ namespace edz::ui::element {
 
         void draw(NVGcontext *vg, int x, int y, unsigned width, unsigned height, brls::Style *style, brls::FrameContext *ctx) override;
         void layout(NVGcontext* vg, brls::Style *style, brls::FontStash *stash) override;
-        View* requestFocus(brls::FocusDirection direction, View *oldFocus, bool fromUp = false) override;
-    
-        void drawHighlight(NVGcontext* vg, brls::ThemeValues* theme, float alpha, brls::Style* style, bool background) override;
+        View* getNextFocus(brls::FocusDirection direction, void* parentUserdata) override;
 
     private:
     

--- a/application/include/ui/pages/page_fullscreen_image.hpp
+++ b/application/include/ui/pages/page_fullscreen_image.hpp
@@ -32,7 +32,6 @@ namespace edz::ui::page {
 
         void draw(NVGcontext* vg, int x, int y, unsigned width, unsigned height, brls::Style* style, brls::FrameContext* ctx) override;
         void layout(NVGcontext* vg, brls::Style* style, brls::FontStash* stash) override;
-        brls::View* requestFocus(brls::FocusDirection direction, brls::View* oldFocus, bool fromUp = false) override;
 
     private:
         brls::Image *m_image = nullptr;

--- a/application/include/ui/pages/page_login.hpp
+++ b/application/include/ui/pages/page_login.hpp
@@ -31,7 +31,8 @@ namespace edz::ui::page {
 
         void draw(NVGcontext* vg, int x, int y, unsigned width, unsigned height, brls::Style* style, brls::FrameContext* ctx) override;
         void layout(NVGcontext* vg, brls::Style* style, brls::FontStash* stash) override;
-        brls::View* requestFocus(brls::FocusDirection direction, brls::View* oldFocus, bool fromUp = false) override;
+        brls::View* getNextFocus(brls::FocusDirection direction, void* oldFocus) override;
+        brls::View* getDefaultFocus() override;
 
         bool onCancel();
 

--- a/application/include/ui/pages/page_splash.hpp
+++ b/application/include/ui/pages/page_splash.hpp
@@ -38,7 +38,6 @@ namespace edz::ui::page {
 
         void draw(NVGcontext* vg, int x, int y, unsigned width, unsigned height, brls::Style* style, brls::FrameContext* ctx) override;
         void layout(NVGcontext* vg, brls::Style* style, brls::FontStash* stash) override;
-        brls::View* requestFocus(brls::FocusDirection direction, brls::View* oldFocus, bool fromUp = false) override;
 
     private:
         brls::Image *m_logo = nullptr;

--- a/application/source/helpers/debug_helpers.cpp
+++ b/application/source/helpers/debug_helpers.cpp
@@ -207,7 +207,7 @@ extern "C" {
                 break;
         }
 
-        brls::Application::removeFocus();
+        brls::Application::giveFocus(nullptr);
         edz::ui::Gui::fatal("%s\n\n%s: %s\nPC: BASE + 0x%016lx",
             "A fatal exception occured!",
             "Reason",

--- a/application/source/main.cpp
+++ b/application/source/main.cpp
@@ -41,7 +41,7 @@ EResult initServices() {
     // Already initialized by Borealis but also used in EdiZon: romfs, sockets, pl and set:sys
 
     // Initialize Borealis (UI library)
-    if (!brls::Application::init())
+    if (!brls::Application::init("Edizon"))
         return ResultEdzBorealisInitFailed;
 
     // Extra fonts

--- a/application/source/main.cpp
+++ b/application/source/main.cpp
@@ -125,7 +125,8 @@ EResult createFolderStructure() {
         EDIZON_SCRIPTS_DIR,
         EDIZON_LIBS_DIR,
         EDIZON_CHEATS_DIR,
-        EDIZON_TMP_DIR};
+        EDIZON_TMP_DIR
+    };
 
     for (auto path : paths) {
         hlp::Folder folder(path);

--- a/application/source/ui/elements/credit_view.cpp
+++ b/application/source/ui/elements/credit_view.cpp
@@ -60,12 +60,4 @@ namespace edz::ui::element {
         this->height = 120;
     }
 
-    brls::View* CreditView::requestFocus(brls::FocusDirection direction, brls::View *oldFocus, bool fromUp) {        
-        return nullptr;
-    }
-
-    void CreditView::drawHighlight(NVGcontext* vg, brls::ThemeValues* theme, float alpha, brls::Style* style, bool background) {
-
-    }
-
 }

--- a/application/source/ui/elements/focusable_table.cpp
+++ b/application/source/ui/elements/focusable_table.cpp
@@ -31,12 +31,8 @@ namespace edz::ui::element {
     FocusableTable::~FocusableTable() {
     }
 
-    brls::View* FocusableTable::requestFocus(brls::FocusDirection direction, brls::View *oldFocus, bool fromUp) {        
+    brls::View* FocusableTable::getDefaultFocus() {        
         return this;
-    }
-
-    void FocusableTable::drawHighlight(NVGcontext* vg, brls::ThemeValues* theme, float alpha, brls::Style* style, bool background) {
-        // The view has to be focusable for scrolling to work but we don't want the highlight to be drawn
     }
 
 }

--- a/application/source/ui/elements/hex_editor.cpp
+++ b/application/source/ui/elements/hex_editor.cpp
@@ -91,10 +91,8 @@ namespace edz::ui::element {
         this->m_historyLabel->setBoundaries(50, 720 - style->AppletFrame.footerHeight - 50, 1280 - 100, 50);
     }
 
-    brls::View* HexEditor::requestFocus(brls::FocusDirection direction, brls::View *oldFocus, bool fromUp) {    
+    brls::View* HexEditor::getNextFocus(brls::FocusDirection direction, void* oldFocus) {    
         switch (direction) {
-            case brls::FocusDirection::NONE:
-                break;
             case brls::FocusDirection::UP:
                 this->m_selectY = std::max(1, this->m_selectY - 1);
                 break;
@@ -109,14 +107,14 @@ namespace edz::ui::element {
                 break;
         }   
         
+        return this->getDefaultFocus();
+    }
+
+    brls::View* HexEditor::getDefaultFocus() {
         this->m_selectWidth = static_cast<u8>(this->m_selectionType[(this->m_selectY - 1) * 2 + this->m_selectX / 8]);
         this->m_selectX = (this->m_selectX / this->m_selectWidth) * this->m_selectWidth;
 
         return this;
-    }
-
-    void HexEditor::drawHighlight(NVGcontext* vg, brls::ThemeValues* theme, float alpha, brls::Style* style, bool background) {
-
     }
 
     bool HexEditor::onClick() {

--- a/application/source/ui/elements/title_button.cpp
+++ b/application/source/ui/elements/title_button.cpp
@@ -22,7 +22,8 @@
 namespace edz::ui::element {
 
     TitleButton::TitleButton(std::unique_ptr<save::Title> &title, u8 column) : m_title(title), m_column(column) {
-        this->m_image = new brls::Image(title->getIcon().data(), title->getIcon().size());
+        this->m_image = new brls::Image();
+        this->m_image->setImage(title->getIcon().data(), title->getIcon().size());
         this->m_image->setParent(this);
         this->m_image->setScaleType(brls::ImageScaleType::SCALE);
         this->m_image->invalidate();
@@ -36,12 +37,7 @@ namespace edz::ui::element {
 
 
     void TitleButton::draw(NVGcontext *vg, int x, int y, unsigned width, unsigned height, brls::Style *style, brls::FrameContext *ctx) {
-        View *baseView = this->getParent()->getParent();
-
-        nvgSave(vg);
-        nvgScissor(vg, baseView->getX(), baseView->getY(), baseView->getWidth(), baseView->getHeight());
         this->m_image->frame(ctx);
-        nvgRestore(vg);
     }
 
     void TitleButton::layout(NVGcontext* vg, brls::Style *style, brls::FontStash *stash) {

--- a/application/source/ui/elements/title_button.cpp
+++ b/application/source/ui/elements/title_button.cpp
@@ -22,7 +22,7 @@
 namespace edz::ui::element {
 
     TitleButton::TitleButton(std::unique_ptr<save::Title> &title, u8 column) : m_title(title), m_column(column) {
-        this->m_image = new brls::Image(title->getIcon());
+        this->m_image = new brls::Image(title->getIcon().data(), title->getIcon().size());
         this->m_image->setParent(this);
         this->m_image->setScaleType(brls::ImageScaleType::SCALE);
         this->m_image->invalidate();
@@ -52,7 +52,7 @@ namespace edz::ui::element {
         this->m_image->invalidate();
     }
 
-    brls::View* TitleButton::requestFocus(brls::FocusDirection direction, brls::View *oldFocus, bool fromUp) {   
+    brls::View* TitleButton::getDefaultFocus() {   
         return this;
     }
 
@@ -106,22 +106,22 @@ namespace edz::ui::element {
             
                 if (newTitleButton != nullptr) {
                     if (oldTitleButton->getParent() != newTitleButton->getParent()) {
-                        this->focusedIndex = oldTitleButton->getColumn();
+                        this->defaultFocusedIndex = oldTitleButton->getColumn();
                         return newTitleButton;
                     } else return oldFocus;
                 } else return oldFocus;
             } else return oldFocus;
         }
 
-        return BoxLayout::defaultFocus(oldFocus);
+        return BoxLayout::getDefaultFocus();
     }
 
-    brls::View* HorizontalTitleList::requestFocus(brls::FocusDirection direction, View *oldFocus, bool fromUp) {
+    brls::View* HorizontalTitleList::getNextFocus(brls::FocusDirection direction, void* oldFocus) {
         if (direction == brls::FocusDirection::LEFT)
             if (oldFocus == this->getChildren()[0]->view)
-                return this->getParent()->getParent()->requestFocus(direction, oldFocus, fromUp);
+                return this->getParent()->getParent()->getNextFocus(direction, oldFocus);
 
-        return BoxLayout::requestFocus(direction, oldFocus, fromUp);
+        return BoxLayout::getNextFocus(direction, oldFocus);
     }
 
 }

--- a/application/source/ui/elements/title_info.cpp
+++ b/application/source/ui/elements/title_info.cpp
@@ -26,7 +26,7 @@
 namespace edz::ui::element {
 
     TitleInfo::TitleInfo(std::vector<u8> &buffer, std::unique_ptr<save::Title> &title) {
-        this->m_image = new brls::Image(buffer);
+        this->m_image = new brls::Image(buffer.data(), buffer.size());
         this->m_image->setParent(this);
         this->m_image->setScaleType(brls::ImageScaleType::FIT);      
 
@@ -59,12 +59,8 @@ namespace edz::ui::element {
         this->m_table->invalidate();
     }
 
-    brls::View* TitleInfo::requestFocus(brls::FocusDirection direction, brls::View *oldFocus, bool fromUp) {        
+    brls::View* TitleInfo::getNextFocus(brls::FocusDirection direction, void* parentUserdata) {        
         return this;
-    }
-
-    void TitleInfo::drawHighlight(NVGcontext* vg, brls::ThemeValues* theme, float alpha, brls::Style* style, bool background) {
-        // The view has to be focusable for scrolling to work but we don't want the highlight to be drawn
     }
 
 }

--- a/application/source/ui/elements/title_info.cpp
+++ b/application/source/ui/elements/title_info.cpp
@@ -26,7 +26,8 @@
 namespace edz::ui::element {
 
     TitleInfo::TitleInfo(std::vector<u8> &buffer, std::unique_ptr<save::Title> &title) {
-        this->m_image = new brls::Image(buffer.data(), buffer.size());
+        this->m_image = new brls::Image();
+        this->m_image->setImage(buffer.data(), buffer.size());
         this->m_image->setParent(this);
         this->m_image->setScaleType(brls::ImageScaleType::FIT);      
 

--- a/application/source/ui/gui_cheat_engine.cpp
+++ b/application/source/ui/gui_cheat_engine.cpp
@@ -473,12 +473,9 @@ namespace edz::ui {
         });
 
         // Sidebar 
-        std::vector<u8> thumbnailBuffer(1280 * 720 * 4);
+        auto titleIcon = save::Title::getRunningTitle()->getIcon();
 
-        if (save::Title::getLastTitleForgroundImage(&thumbnailBuffer[0]).failed())
-            std::fill(thumbnailBuffer.begin(), thumbnailBuffer.end(), 0x80);
-
-        this->m_rootFrame->getSidebar()->setThumbnail(thumbnailBuffer.data(), thumbnailBuffer.size());
+        this->m_rootFrame->getSidebar()->setThumbnail(titleIcon.data(), titleIcon.size());
         
 
         this->m_contentLayers = new brls::LayerView();
@@ -490,6 +487,7 @@ namespace edz::ui {
 
         this->m_rootFrame->setContentView(this->m_contentLayers);
 
+        this->m_rootFrame->getSidebar()->getButton()->setLabel("Search");
         this->m_rootFrame->getSidebar()->getButton()->getClickEvent()->subscribe([this](brls::View *view) {
             Gui::runAsyncWithDialog([this] {
 

--- a/application/source/ui/gui_cheat_engine.cpp
+++ b/application/source/ui/gui_cheat_engine.cpp
@@ -152,7 +152,8 @@ namespace edz::ui {
         });
 
         this->m_knownPrimaryAligned->getClickEvent()->subscribe([this](brls::View *view) {
-            this->m_unknownPrimaryAligned->setToggleState(this->m_knownPrimaryAligned->getToggleState());
+            if (this->m_unknownPrimaryAligned->getToggleState() != this->m_knownPrimaryAligned->getToggleState())
+                this->m_unknownPrimaryAligned->onClick();   // TODO: This probably won't work. Check later
 
             this->m_alignedSearch = this->m_knownPrimaryAligned->getToggleState();
         });
@@ -261,7 +262,8 @@ namespace edz::ui {
         });
 
         this->m_unknownPrimaryAligned->getClickEvent()->subscribe([this](brls::View *view) {
-            this->m_knownPrimaryAligned->setToggleState(this->m_unknownPrimaryAligned->getToggleState());
+            if (this->m_knownPrimaryAligned->getToggleState() != this->m_unknownPrimaryAligned->getToggleState())
+                this->m_knownPrimaryAligned->onClick(); // TODO: This probably won't work, check later
 
             this->m_alignedSearch = this->m_unknownPrimaryAligned->getToggleState();
         });
@@ -391,7 +393,7 @@ namespace edz::ui {
 
 
     brls::View* GuiCheatEngine::setupUI() {
-        this->m_rootFrame = new brls::ThumbnailFrame("edz.gui.cheatengine.sidebar.search"_lang);
+        this->m_rootFrame = new brls::ThumbnailFrame();
         this->m_rootFrame->setTitle("edz.gui.cheatengine.title"_lang);
 
         this->m_rootFrame->registerAction("Memory View", brls::Key::X, [this]() {
@@ -421,11 +423,11 @@ namespace edz::ui {
         this->m_rootFrame->registerAction("Reset Search", brls::Key::MINUS, [this]() {
             if (this->m_selectedSearchLayer == SearchLayer::KnownSecondary) {
                 this->m_nextSearchLayer = SearchLayer::KnownPrimary;
-                Gui::runLater([this]{ brls::Application::requestFocus(this->m_rootFrame, brls::FocusDirection::NONE); }, 10);
+                Gui::runLater([this]{ brls::Application::giveFocus(this->m_rootFrame); }, 10);
             }
             else if (this->m_selectedSearchLayer == SearchLayer::UnknownSecondary) {
                 this->m_nextSearchLayer = SearchLayer::UnknownPrimary;
-                Gui::runLater([this]{ brls::Application::requestFocus(this->m_rootFrame, brls::FocusDirection::NONE); }, 10);
+                Gui::runLater([this]{ brls::Application::giveFocus(this->m_rootFrame); }, 10);
             }
                 if (this->m_pattern != nullptr)
                     delete[] this->m_pattern;
@@ -444,7 +446,8 @@ namespace edz::ui {
                 this->m_knownPrimaryDataType->setSelectedValue(0);
                 this->m_knownPrimaryValue->setValue("0");
                 this->m_knownPrimarySize->setValue("1");
-                this->m_knownPrimaryAligned->setToggleState(true);
+                if (!this->m_knownPrimaryAligned->getToggleState())
+                    this->m_knownPrimaryAligned->onClick();
 
                 this->m_knownSecondaryFoundAddresses->setValue("0");
                 this->m_knownSecondarySearchType->setSelectedValue(0);
@@ -454,7 +457,8 @@ namespace edz::ui {
                 this->m_unknownPrimarySearchRegion->setSelectedValue(0);
                 this->m_unknownPrimaryDataType->setSelectedValue(0);
                 this->m_unknownPrimarySize->setValue("0");
-                this->m_unknownPrimaryAligned->setToggleState(true);
+                if (!this->m_unknownPrimaryAligned->getToggleState())
+                    this->m_unknownPrimaryAligned->onClick();
 
                 this->m_unknownSecondaryFoundAddresses->setValue("0");
                 this->m_unknownSecondaryUnknownSearchType->setSelectedValue(0);
@@ -474,7 +478,7 @@ namespace edz::ui {
         if (save::Title::getLastTitleForgroundImage(&thumbnailBuffer[0]).failed())
             std::fill(thumbnailBuffer.begin(), thumbnailBuffer.end(), 0x80);
 
-        this->m_rootFrame->getSidebar()->setThumbnail(&thumbnailBuffer[0], 1280, 720);
+        this->m_rootFrame->getSidebar()->setThumbnail(thumbnailBuffer.data(), thumbnailBuffer.size());
         
 
         this->m_contentLayers = new brls::LayerView();
@@ -520,7 +524,7 @@ namespace edz::ui {
 
         if (this->m_nextSearchLayer != this->m_selectedSearchLayer) {
             this->m_contentLayers->changeLayer(u8(this->m_nextSearchLayer));
-            brls::Application::requestFocus(this->m_contentLayers, brls::FocusDirection::NONE);
+            brls::Application::giveFocus(this->m_contentLayers);
 
             this->m_selectedSearchLayer = this->m_nextSearchLayer;
 

--- a/application/source/ui/gui_game_image.cpp
+++ b/application/source/ui/gui_game_image.cpp
@@ -31,7 +31,7 @@ namespace edz::ui {
         if (save::Title::getLastTitleForgroundImage(&thumbnailBuffer[0]).failed())
             std::fill(thumbnailBuffer.begin(), thumbnailBuffer.end(), 0x80);
 
-        auto gameImage = new brls::Image(&thumbnailBuffer[0], 1280, 720);
+        auto gameImage = new brls::Image(thumbnailBuffer.data(), thumbnailBuffer.size());
 
         return new page::PageFullscreenImage(gameImage);
     }

--- a/application/source/ui/gui_game_image.cpp
+++ b/application/source/ui/gui_game_image.cpp
@@ -29,9 +29,10 @@ namespace edz::ui {
         
         std::vector<u8> thumbnailBuffer(1280 * 720 * 4);
         if (save::Title::getLastTitleForgroundImage(&thumbnailBuffer[0]).failed())
-            std::fill(thumbnailBuffer.begin(), thumbnailBuffer.end(), 0x80);
+            std::fill(thumbnailBuffer.begin(), thumbnailBuffer.end(), 0x00);
 
-        auto gameImage = new brls::Image(thumbnailBuffer.data(), thumbnailBuffer.size());
+        auto gameImage = new brls::Image();
+        gameImage->setImageRGBA(thumbnailBuffer.data(), 1280, 720);
 
         return new page::PageFullscreenImage(gameImage);
     }

--- a/application/source/ui/gui_main.cpp
+++ b/application/source/ui/gui_main.cpp
@@ -636,7 +636,7 @@ namespace edz::ui {
                     for (auto &cheatToggle : GuiMain::m_cheatToggleListItems) {
                         bool isEnabled = cheat::CheatManager::getCheats()[i++]->isEnabled();
                         if (cheatToggle->getToggleState() != isEnabled)
-                            cheatToggle->onClick(); // TODO: This should work properly without setToggle, but need to verify
+                            cheatToggle->setToggleState(isEnabled);
                     }
                 }, 20);
 
@@ -952,6 +952,8 @@ namespace edz::ui {
         rootFrame->addSeparator();
         rootFrame->addTab("edz.gui.main.settings.tab"_lang, this->m_settingsList);
         rootFrame->addTab("edz.gui.main.about.tab"_lang, this->m_aboutList);
+
+        rootFrame->registerAction("Back", brls::Key::B, [](){ brls::Application::quit(); return true; });
 
         #if DEBUG_MODE_ENABLED
             rootFrame->setFooterText("edz.debugmode"_lang);

--- a/application/source/ui/pages/page_fullscreen_image.cpp
+++ b/application/source/ui/pages/page_fullscreen_image.cpp
@@ -27,6 +27,8 @@ namespace edz::ui::page {
         this->m_image = image;
         this->m_image->setScaleType(brls::ImageScaleType::FIT);
         this->m_image->setParent(this);
+
+        this->registerAction("Back", brls::Key::B, [](){ brls::Application::popView(); return true; });
     }
 
     PageFullscreenImage::~PageFullscreenImage() {
@@ -39,6 +41,7 @@ namespace edz::ui::page {
 
     void PageFullscreenImage::layout(NVGcontext* vg, brls::Style* style, brls::FontStash* stash) {
         this->m_image->setBoundaries(0, 0, 1280, 720);
+        this->m_image->invalidate();
     }
 
 }

--- a/application/source/ui/pages/page_fullscreen_image.cpp
+++ b/application/source/ui/pages/page_fullscreen_image.cpp
@@ -37,10 +37,6 @@ namespace edz::ui::page {
         this->m_image->frame(ctx);
     }
 
-    brls::View* PageFullscreenImage::requestFocus(brls::FocusDirection direction, brls::View* oldFocus, bool fromUp) {
-        return nullptr;
-    }
-
     void PageFullscreenImage::layout(NVGcontext* vg, brls::Style* style, brls::FontStash* stash) {
         this->m_image->setBoundaries(0, 0, 1280, 720);
     }

--- a/application/source/ui/pages/page_login.cpp
+++ b/application/source/ui/pages/page_login.cpp
@@ -101,10 +101,7 @@ namespace edz::ui::page {
         this->m_loginBtn->frame(ctx);
     }
 
-    brls::View* PageLogin::requestFocus(brls::FocusDirection direction, brls::View* oldFocus, bool fromUp) {
-        if (direction == brls::FocusDirection::NONE)
-            return this->m_emailItem;
-
+    brls::View* PageLogin::getNextFocus(brls::FocusDirection direction, void* oldFocus) {
         if (direction == brls::FocusDirection::DOWN) {
             if (oldFocus == this->m_emailItem)
                 return this->m_passwordItem;
@@ -118,6 +115,10 @@ namespace edz::ui::page {
         }
 
         return nullptr;
+    }
+
+    brls::View* PageLogin::getDefaultFocus() {
+        return this->m_emailItem;
     }
 
     void PageLogin::layout(NVGcontext* vg, brls::Style* style, brls::FontStash* stash) {

--- a/application/source/ui/pages/page_splash.cpp
+++ b/application/source/ui/pages/page_splash.cpp
@@ -24,7 +24,8 @@
 namespace edz::ui::page {
 
     PageSplash::PageSplash(PageSplash::WarningType warningType) {
-        this->m_logo = new brls::Image("romfs:/assets/icon_edz_color.jpg");
+        this->m_logo = new brls::Image();
+        this->m_logo->setImage("romfs:/assets/icon_edz_color.jpg");
         this->m_logo->setParent(this);
         
         if (warningType == WarningType::TooLowAtmosphereVersion) {

--- a/application/source/ui/pages/page_splash.cpp
+++ b/application/source/ui/pages/page_splash.cpp
@@ -64,10 +64,6 @@ namespace edz::ui::page {
             this->m_warning->frame(ctx);
     }
 
-    brls::View* PageSplash::requestFocus(brls::FocusDirection direction, brls::View* oldFocus, bool fromUp) {
-        return nullptr;
-    }
-
     void PageSplash::layout(NVGcontext* vg, brls::Style* style, brls::FontStash* stash) {
         this->m_logo->setBoundaries((1280 - 256) / 2, (720 - 256) / 2, 256, 256);
 

--- a/common/include/edizon.hpp
+++ b/common/include/edizon.hpp
@@ -39,8 +39,8 @@
 
 #define BACKUP_FILE_EXTENSION           ".edz"
 
-/* Whether the splash screen should be displayed on launch */
-#define SPLASH_ENABLED                  false
+/* Whether the splash screen should be displayed on launch. This does not actually make EdiZon start faster, instead it will display a black screen during loading */
+#define SPLASH_ENABLED                  true
 
 /* If the user has more than this number of games installed, don't load any extra information of games that aren't installed anymore but have save files left */
 #define MAX_TITLE_FROM_SAVE_DATA        20

--- a/common/include/edizon.hpp
+++ b/common/include/edizon.hpp
@@ -40,7 +40,7 @@
 #define BACKUP_FILE_EXTENSION           ".edz"
 
 /* Whether the splash screen should be displayed on launch */
-#define SPLASH_ENABLED                  true
+#define SPLASH_ENABLED                  false
 
 /* If the user has more than this number of games installed, don't load any extra information of games that aren't installed anymore but have save files left */
 #define MAX_TITLE_FROM_SAVE_DATA        20


### PR DESCRIPTION
 Currently requires a PR with minor changes to Borealis: https://github.com/natinusala/borealis/pull/43

To do's: 

- [ ] Title sorting is disabled. Should be possible to fix with the current PR for Borealis.

- [x] Game screen doesn't display properly in cheat engine

- [ ] Cursor gets locked into the Save Repositories tab currently, have to exit EdiZon to fix.

- [x] An ugly hack was used to compensate the lacking of setToggleState in latest Borealis. Need to check if it even works properly.

- [x] Splash screen disabled as it is causing a fatal for some reason

- [x] B button on main screen doesn't exit app (I think it used to?)

- [ ] Probably lacking stability